### PR TITLE
made package 2.7-compatible, minor cleanup, Button callback bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The good:
 
 - **Portability.** This package is pure Python that relies on only the standard library. This will not change while I have breath in my body.
 
-  Consequently, it should be usable out of the box for every single person with Python 3, without installing Tk or Qt or wxWidgets or PyObjC or any of that stuff.
+  Consequently, it should be usable out of the box for every single person with Python 2.7 or later, without installing Tk or Qt or wxWidgets or PyObjC or any of that stuff.
 
 - **Easy to learn.** Making simple GUIs for simple tasks is simple. Check out the `examples` directory (particularly `examples/longrunning.py` for a vaguely realistic use case).
 

--- a/command_stream.py
+++ b/command_stream.py
@@ -1,4 +1,9 @@
-import time
+import sys
+if sys.version_info >= (3, 0):
+  from time import monotonic as time
+else:
+  from time import time
+
 import threading
 
 class Empty(Exception):
@@ -9,7 +14,7 @@ class Destroyed(Exception):
   """Raised when trying to get/put on a destroyed CommandStream"""
   pass
 
-class CommandStream:
+class CommandStream(object):
   def __init__(self):
     self.commands = []
     self.destroyed = False
@@ -41,9 +46,9 @@ class CommandStream:
       elif timeout < 0:
         raise ValueError("'timeout' must be a non-negative number")
       else:
-        endtime = time.monotonic() + timeout
+        endtime = time() + timeout
         while self.empty() and not self.destroyed:
-          remaining = endtime - time.monotonic()
+          remaining = endtime - time()
           if remaining <= 0.0:
             raise Empty
           self.not_empty.wait(remaining)

--- a/examples/longrunning.py
+++ b/examples/longrunning.py
@@ -1,6 +1,5 @@
 import os
 import threading
-import pprint
 import collections
 from browsergui import GUI, Paragraph, Text, CodeSnippet, CodeBlock, Container, run
 

--- a/gui.py
+++ b/gui.py
@@ -49,7 +49,7 @@ def event_stop_listening_command(element, event_type):
       type=json.dumps(event_type),
       id=json.dumps(element.id))
 
-class GUI:
+class GUI(object):
   def __init__(self, *elements):
     self.tag = parse_tag('<body></body>')
     self.tag.attributes['id'] = 'body'
@@ -74,7 +74,6 @@ class GUI:
 
   def handle_event(self, event):
     element = self.elements_by_id[event['id']]
-    print("having {} handle event {}".format(element, event))
     element.handle_event(event)
 
   @property
@@ -91,7 +90,8 @@ class GUI:
 
   def walk_elements(self):
     for element in self.children:
-      yield from element.walk()
+      for descendant in element.walk():
+        yield descendant
 
   def append(self, child):
     if not isinstance(child, Element):

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -102,25 +102,21 @@ class ElementTest(BrowserGUITestCase):
     self.assertEqual(list(container.children), [])
 
   def test_callbacks(self):
-    last_event = None
-    def set_event(event):
-      nonlocal last_event
-      last_event = event
 
     e = Element(tag_name="a")
-    e.add_callback(CLICK, set_event)
-    e.add_callback(KEYDOWN, set_event)
+    e.add_callback(CLICK, self.set_last_event)
+    e.add_callback(KEYDOWN, self.set_last_event)
 
     e.handle_event({'type': CLICK, 'id': e.id})
-    self.assertEqual(last_event, {'type': CLICK, 'id': e.id})
+    self.assertEqual(self.last_event, {'type': CLICK, 'id': e.id})
 
     e.handle_event({'type': KEYDOWN, 'id': e.id, 'key': 'a'})
-    self.assertEqual(last_event, {'type': KEYDOWN, 'id': e.id, 'key': 'a'})
+    self.assertEqual(self.last_event, {'type': KEYDOWN, 'id': e.id, 'key': 'a'})
 
-    e.remove_callback(CLICK, set_event)
+    e.remove_callback(CLICK, self.set_last_event)
     with self.assertRaises(NoSuchCallbackError):
-      e.remove_callback(CLICK, set_event)
+      e.remove_callback(CLICK, self.set_last_event)
 
     self.assertEqual(list(e.callbacks[CLICK]), [])
-    self.assertEqual(list(e.callbacks[KEYDOWN]), [set_event])
+    self.assertEqual(list(e.callbacks[KEYDOWN]), [self.set_last_event])
     self.assertEqual(list(e.callbacks[KEYUP]), [])

--- a/tests/test_specific_elements.py
+++ b/tests/test_specific_elements.py
@@ -35,17 +35,15 @@ class ButtonTest(BrowserGUITestCase):
     self.assertEqual(Button().text, "Click!")
 
   def test_set_callback(self):
-    clicked = False
-    def toggle():
-      nonlocal clicked
-      clicked = True
-
-    b = Button(callback=(lambda event: toggle()))
+    b = Button(callback=self.set_last_event)
     b.handle_event({'type': CLICK, 'id': b.id})
-    self.assertTrue(clicked)
+    self.assertEqual(self.last_event, {'type': CLICK, 'id': b.id})
 
-    clicked = False
-    b = Button()
-    b.set_callback(lambda event: toggle())
+    self.last_event = None
+    b.set_callback(lambda event: None)
     b.handle_event({'type': CLICK, 'id': b.id})
-    self.assertTrue(clicked)
+    self.assertIsNone(self.last_event)
+
+    b.set_callback(self.set_last_event)
+    b.handle_event({'type': CLICK, 'id': b.id})
+    self.assertEqual(self.last_event, {'type': CLICK, 'id': b.id})


### PR DESCRIPTION
Button.set_callback now obliterates the old callback like it should.

The compatibility part entailed:
- tweaking imports depending on sys.version_info
- making classes explicitly inherit from object
- replacing 'yield from x' with 'for y in x: yield y'
- making super() arguments explicit
- making Container's inline kw-only argument 'kwargs' instead
  (yes, ugly, but the other 2.7-compatible alternatives are bad too)
- making de-facto global variables in the server truly global
- refactoring tests that used the nonlocal keyword
