### PR TITLE
fix import bug for Python 3.0-3.2

### DIFF
--- a/browsergui/commands/command_stream.py
+++ b/browsergui/commands/command_stream.py
@@ -1,5 +1,5 @@
 import sys
-if sys.version_info >= (3, 0):
+if sys.version_info >= (3, 3):
   from time import monotonic as time
 else:
   from time import time

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1.0.1',
+    version='0.1.0.2',
 
     description='A GUI toolkit targeting browsers',
     long_description=long_description,


### PR DESCRIPTION
I thought that time.monotonic was introduced in 3.0; it was actually
introduced in 3.3. Versions between 3 and 3.2 would try to import it
and fail.
