### PR TITLE
remove GUI.register_element; instead, manually traverse tree. Premature optimization.

### DIFF
--- a/browsergui/elements/__init__.py
+++ b/browsergui/elements/__init__.py
@@ -52,6 +52,10 @@ class Element(Node, HasCallbacks, HasStyling):
     """The GUI the element belongs to, or None if there is none."""
     return (None if self.orphaned else self.parent.gui)
 
+  def mark_dirty(self):
+    if self.gui is not None:
+      self.gui.change_tracker.mark_dirty()
+
 
 class Container(Element, SequenceNode):
   """Contains and groups other elements."""
@@ -62,26 +66,22 @@ class Container(Element, SequenceNode):
   def append(self, child):
     super(Element, self).append(child)
     self.tag.appendChild(child.tag)
-    if self.gui is not None:
-      self.gui.register_element(child)
+    self.mark_dirty()
 
   def insert_before(self, new_child, reference_child):
     super(Element, self).insert_before(new_child, reference_child)
     self.tag.insertBefore(new_child.tag, reference_child.tag)
-    if self.gui is not None:
-      self.gui.register_element(new_child)
+    self.mark_dirty()
 
   def insert_after(self, new_child, reference_child):
     super(Element, self).insert_after(new_child, reference_child)
     self.tag.insertBefore(new_child.tag, reference_child.tag.nextSibling)
-    if self.gui is not None:
-      self.gui.register_element(new_child)
+    self.mark_dirty()
 
   def disown(self, child):
     super(Element, self).disown(child)
     self.tag.removeChild(child.tag)
-    if self.gui is not None:
-      self.gui.unregister_element(child)
+    self.mark_dirty()
 
 
 class LeafElement(Element, LeafNode):

--- a/browsergui/elements/_hascallbacks.py
+++ b/browsergui/elements/_hascallbacks.py
@@ -26,8 +26,7 @@ class HasCallbacks(object):
     """
     self.callbacks[event_type].append(callback)
     self.tag.setAttribute('on'+event_type, _javascript_to_notify_server(self, event_type))
-    if self.gui is not None:
-      self.gui.change_tracker.mark_dirty()
+    self.mark_dirty()
 
   def remove_callback(self, event_type, callback):
     """Stops calling ``callback`` when events of ``event_type`` are handled.
@@ -41,8 +40,7 @@ class HasCallbacks(object):
 
     if not self.callbacks[event_type]:
       self.tag.removeAttribute('on'+event_type)
-      if self.gui is not None:
-        self.gui.change_tracker.mark_dirty()
+      self.mark_dirty()
 
   def handle_event(self, event):
     """Calls all the callbacks registered for the given event's type.

--- a/browsergui/elements/_hasstyling.py
+++ b/browsergui/elements/_hasstyling.py
@@ -27,5 +27,4 @@ class HasStyling(object):
 
   def _update_styles(self):
     self.tag.setAttribute('style', styling_to_css(self._styling))
-    if self.gui is not None:
-      self.gui.change_tracker.mark_dirty()
+    self.mark_dirty()

--- a/browsergui/elements/text.py
+++ b/browsergui/elements/text.py
@@ -23,8 +23,7 @@ class Text(LeafElement):
       return
 
     self._text.data = value
-    if self.gui is not None:
-      self.gui.change_tracker.mark_dirty()
+    self.mark_dirty()
 
 class CodeSnippet(Text):
   """Inline text representing computer code."""

--- a/browsergui/gui.py
+++ b/browsergui/gui.py
@@ -38,8 +38,6 @@ class GUI(object):
     self.make_new_document(destroy=False)
     super(GUI, self).__init__(**kwargs)
 
-    self.elements_by_id = {}
-
     for element in elements:
       self.append(element)
 
@@ -48,8 +46,12 @@ class GUI(object):
 
     :param dict event:
     """
-    element = self.elements_by_id[event['id']]
-    element.handle_event(event)
+    for element in self.body.walk():
+      if element.id == event['id']:
+        element.handle_event(event)
+        break
+    else:
+      raise KeyError('no element with id {!r}'.format(event['id']))
 
   def append(self, child):
     """To be cleaned up, per issue #23."""
@@ -58,18 +60,6 @@ class GUI(object):
   def disown(self, child):
     """To be cleaned up, per issue #23."""
     self.body.disown(child)
-
-  def register_element(self, element):
-    """docstring"""
-    for subelement in element.walk():
-      self.elements_by_id[subelement.id] = subelement
-    self.change_tracker.mark_dirty()
-
-  def unregister_element(self, element):
-    """docstring"""
-    for subelement in element.walk():
-      del self.elements_by_id[subelement.id]
-    self.change_tracker.mark_dirty()
 
   def make_new_document(self, destroy=True):
     if destroy:


### PR DESCRIPTION
Also, give Elements a `mark_dirty()` method that encapsulates the common `if self.gui is not None: self.gui.change_tracker.mark_dirty()` pattern.
