### PR TITLE
refactor tour to use Text.set_text, eliminating ugly functions

### DIFF
--- a/browsergui/examples/tour.py
+++ b/browsergui/examples/tour.py
@@ -3,42 +3,28 @@ from browsergui import *
 
 click_count = 0
 def main():
-  def note_click():
-    global click_count
-    click_count += 1
-    button.text = 'Button ({} clicks)'.format(click_count)
-  button = Button('Button (0 clicks)', callback=note_click)
+  click_count = Text('0')
+  button = Button('Click me!', callback=lambda: click_count.set_text(int(click_count.text) + 1))
 
-  reversed_text_field_contents = Text(''.join(reversed('Reversed')))
-  def note_text_field_change():
-    reversed_text_field_contents.text = ''.join(reversed(text_field.value))
-  text_field = TextField(value='Reversed', change_callback=note_text_field_change)
+  reversed_text_field_contents = Text('')
+  text_field = TextField(change_callback=lambda: reversed_text_field_contents.set_text(''.join(reversed(text_field.value))))
+  text_field.value = 'Reversed'
 
   selected_dropdown_item = Text('')
-  def note_dropdown_change():
-    selected_dropdown_item.text = dropdown.value
-  dropdown = Dropdown(['Dr', 'op', 'do', 'wn'], change_callback=note_dropdown_change)
-  selected_dropdown_item.text = dropdown.value
+  dropdown = Dropdown(['Dr', 'op', 'do', 'wn'], change_callback=lambda: selected_dropdown_item.set_text(dropdown.value))
+  dropdown.value = 'Dr'
 
-  number_field_contents = Text('')
-  def note_number_change():
-    number_field_contents.text = '' if number_field.value is None else str(number_field.value**2)
-  number_field = NumberField(change_callback=note_number_change)
+  number_field_squared = Text('')
+  number_field = NumberField(change_callback=lambda: number_field_squared.set_text('' if number_field.value is None else str(number_field.value**2)))
   number_field.value = 12
 
   colored_text = Text('colored')
-  def note_color_change():
-    colored_text.set_styles(color=color_field.value_to_xml_string(color_field.value))
-  color_field = ColorField(change_callback=note_color_change)
+  color_field = ColorField(change_callback=lambda: colored_text.set_styles(color=color_field.value_to_xml_string(color_field.value)))
   color_field.value = (0, 0, 255)
 
   weekday_text = Text('...')
-  def note_date_change():
-    if date_field.value is None:
-      weekday_text.text = '...'
-    d = date_field.value.weekday()
-    weekday_text.text = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][d]
-  date_field = DateField(change_callback=note_date_change)
+  DAYS = ('Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday')
+  date_field = DateField(change_callback=lambda: weekday_text.set_text('' if date_field.value is None else DAYS[date_field.value.weekday()]))
 
   elements = (
     Container(
@@ -52,10 +38,10 @@ def main():
     Container(
       Text("Input of many flavors:"),
       List(items=(
-        button,
+        Container(Text('Button: '), button, Text(' Clicks: '), click_count),
         Container(Text('Text:'), text_field, reversed_text_field_contents),
         Container(Text('Dropdown:'), dropdown, Text(' Selected: '), selected_dropdown_item),
-        Container(Text('Number:'), number_field, Text('x^2: '), number_field_contents),
+        Container(Text('Number:'), number_field, Text('x^2: '), number_field_squared),
         Container(Text('Color (on some browsers):'), color_field, colored_text),
         Container(Text('Date (on some browsers):'), date_field, Text(' is a '), weekday_text)))),
     Image(os.path.join(os.path.dirname(__file__), 'tour-image.png')),


### PR DESCRIPTION
Before, a common pattern was:

```
t = Text('')
def update_t():
  t.text += 'blah '
b = Button(callback=update_t)
```

With the `set_text` method available, this becomes possible:

```
t = Text('')
b = Button(callback=lambda: t.set_text(t.text + 'blah '))
```

which I think is clearer.
