### PR TITLE
fix error preventing running on Python 2

### DIFF
--- a/browsergui/server/__init__.py
+++ b/browsergui/server/__init__.py
@@ -115,9 +115,12 @@ class GUIRequestHandler(BaseHTTPRequestHandler):
       x = x.encode()
     self.wfile.write(x)
 
-def make_request_handler_class_for_gui(served_gui):
-  class _AnonymousGUIRequestHandlerSubclass(GUIRequestHandler):
+def make_request_handler_class_for_gui(served_gui, quiet=False):
+  class _AnonymousGUIRequestHandlerSubclass(GUIRequestHandler, object):
     gui = served_gui
+  if quiet:
+    def noop(*args): pass
+    _AnonymousGUIRequestHandlerSubclass.log_message = noop
   return _AnonymousGUIRequestHandlerSubclass
 
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
@@ -131,11 +134,7 @@ def run(gui, open_browser=True, port=0, quiet=False):
   :param kwargs: passed through to :func:`serve_forever`
   """
 
-  handler_class = make_request_handler_class_for_gui(gui)
-
-  if quiet:
-    def noop(*args): pass
-    handler_class.log_message = noop
+  handler_class = make_request_handler_class_for_gui(gui, quiet=quiet)
 
   server = ThreadedHTTPServer(('localhost', port), handler_class)
   if port == 0:

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,0 +1,41 @@
+import unittest
+import browsergui
+import threading
+import sys
+if sys.version_info >= (3, 0):
+  from http.client import HTTPConnection
+else:
+  from httplib import HTTPConnection
+
+from browsergui.server import make_request_handler_class_for_gui, ThreadedHTTPServer
+
+class ServerTest(unittest.TestCase):
+  def setUp(self):
+    self.gui = browsergui.GUI()
+    self.handler_class = make_request_handler_class_for_gui(self.gui, quiet=True)
+    self.server = ThreadedHTTPServer(('localhost', 0), self.handler_class)
+
+  def tearDown(self):
+    self.server.socket.close()
+
+  def request(self, *args, **kwargs):
+    timeout = kwargs.pop('timeout', 1)
+    thread = threading.Thread(target=self.server.handle_request)
+    thread.daemon = True
+    thread.start()
+    conn = HTTPConnection('localhost', self.server.socket.getsockname()[1])
+    conn.request(*args, **kwargs)
+    result = conn.getresponse().read()
+
+    thread.join(timeout)
+    if thread.is_alive():
+      raise Exception('request-handling thread timed out')
+
+    return result
+
+  def test_is_responsive(self):
+    # This test assumes that the first request to /command will not block.
+    # (At the time of writing, that's true, because the GUI sends a startup
+    #  command that wipes out and rewrites the entire document. If that stops
+    #  being true, this test will need to be changed.)
+    self.assertTrue(self.request('GET', '/command'))


### PR DESCRIPTION
In Python 2, HTTPRequestHandler doesn't inherit from object, which
was screwing up the class-attribute lookup for the associated GUI.
I made the request-handler subclasses explicitly inherit from object,
and added a weak test to ensure that the server can respond to
at least a single request.
